### PR TITLE
Big Logo Fix

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -66,14 +66,14 @@ const Header = () => {
     <header>
       <Navbar className="navbar fixed-top navbar-expand-lg navbar-dark">
         {/* MHP logo */}
-        <div>
+        {/* <div>
           <Link className="navbar-brand m-0 p-0" to="/">
             <Img
               className="d-inline-block align-top"
               fixed={data.file.childImageSharp.fixed}
             />
           </Link>
-        </div>
+        </div> */}
 
         {/* Button that allows for the menu toggler icon */}
         <button
@@ -90,13 +90,19 @@ const Header = () => {
 
         <CollapsingDiv className="collapse navbar-collapse" id="navbarContent">
           {/* MHP name */}
-          <div>
-            <ul className="navbar-nav ml-auto">{navItem("MHP", "/")}</ul>
+          <div style={{ width: 200, margin: "auto" }}>
+            <ul className="navbar-nav">
+              {navItem("MHP", "/")}
+              <Img
+                className=" align-top"
+                fixed={data.file.childImageSharp.fixed}
+              />
+            </ul>
           </div>
 
           {/* Page Links */}
           <div>
-            <ul className="navbar-nav ml-auto">
+            <ul className="navbar-nav">
               {pageLinks.map((item, index) =>
                 navItem(item.title, item.link, index)
               )}
@@ -104,7 +110,7 @@ const Header = () => {
           </div>
 
           {/* Social Media Icons */}
-          <div>
+          <div style={{ width: 200, margin: "auto" }}>
             <Socials />
           </div>
         </CollapsingDiv>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -81,12 +81,12 @@ const Header = () => {
         <CollapsingDiv className="collapse navbar-collapse" id="navbarContent">
           {/* MHP name */}
           <div style={{ width: 200, margin: "auto" }}>
-            <ul className="navbar-nav">
+            <ul className="navbar-nav pt-1">
               {navItem("MHP", "/")}
 
               {/* MHP logo */}
               <Img
-                className=" align-top"
+                className="align-top"
                 fixed={data.file.childImageSharp.fixed}
               />
             </ul>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -82,13 +82,19 @@ const Header = () => {
           {/* MHP name */}
           <div style={{ width: 200, margin: "auto" }}>
             <ul className="navbar-nav pt-1">
-              {navItem("MHP", "/")}
-
-              {/* MHP logo */}
-              <Img
-                className="align-top"
-                fixed={data.file.childImageSharp.fixed}
-              />
+              <NavLinkContainer
+                className="nav-item"
+                style={{ display: "flex" }}
+              >
+                {/* MHP logo */}
+                <Img
+                  className="align-top"
+                  fixed={data.file.childImageSharp.fixed}
+                />
+                <NavLink className="nav-link" to="/">
+                  MHP
+                </NavLink>
+              </NavLinkContainer>
             </ul>
           </div>
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -65,16 +65,6 @@ const Header = () => {
   return (
     <header>
       <Navbar className="navbar fixed-top navbar-expand-lg navbar-dark">
-        {/* MHP logo */}
-        {/* <div>
-          <Link className="navbar-brand m-0 p-0" to="/">
-            <Img
-              className="d-inline-block align-top"
-              fixed={data.file.childImageSharp.fixed}
-            />
-          </Link>
-        </div> */}
-
         {/* Button that allows for the menu toggler icon */}
         <button
           className="navbar-toggler"
@@ -93,6 +83,8 @@ const Header = () => {
           <div style={{ width: 200, margin: "auto" }}>
             <ul className="navbar-nav">
               {navItem("MHP", "/")}
+
+              {/* MHP logo */}
               <Img
                 className=" align-top"
                 fixed={data.file.childImageSharp.fixed}

--- a/src/components/socials.js
+++ b/src/components/socials.js
@@ -10,6 +10,7 @@ import {
   faFacebookSquare,
   faLinkedin,
   faInstagramSquare,
+  faGithubSquare,
 } from "@fortawesome/free-brands-svg-icons";
 
 const MhpSocialContainer = styled.div`
@@ -19,8 +20,6 @@ const MhpSocialContainer = styled.div`
 
 const SocialLink = styled(Link)`
   padding: 0px 10px 0px 10px;
-  font-size: 28px;
-  height: 28px;
   color: var(--MHP-white);
 
   &:hover {
@@ -41,6 +40,7 @@ const Socials = () => {
             facebook
             instagram
             linkedIn
+            github
           }
         }
       }
@@ -48,19 +48,37 @@ const Socials = () => {
   `);
 
   const social_link = data.file.childMarkdownRemark.frontmatter;
+  const iconSize = 28; //px
 
+  // Inline style for FontAwesomeIcon ensures that the styles gets loaded immediately with the HTML (no huge icons)
   return (
     <MhpSocialContainer>
       <SocialLink to={social_link.facebook}>
-        <FontAwesomeIcon icon={faFacebookSquare} />
+        <FontAwesomeIcon
+          style={{ height: iconSize, width: iconSize }}
+          icon={faFacebookSquare}
+        />
       </SocialLink>
 
       <SocialLink to={social_link.instagram}>
-        <FontAwesomeIcon icon={faInstagramSquare} />
+        <FontAwesomeIcon
+          style={{ height: iconSize, width: iconSize }}
+          icon={faInstagramSquare}
+        />
       </SocialLink>
 
       <SocialLink to={social_link.linkedIn}>
-        <FontAwesomeIcon icon={faLinkedin} />
+        <FontAwesomeIcon
+          style={{ height: iconSize, width: iconSize }}
+          icon={faLinkedin}
+        />
+      </SocialLink>
+
+      <SocialLink to={social_link.github}>
+        <FontAwesomeIcon
+          style={{ height: iconSize, width: iconSize }}
+          icon={faGithubSquare}
+        />
       </SocialLink>
     </MhpSocialContainer>
   );

--- a/src/markdown/socials.md
+++ b/src/markdown/socials.md
@@ -2,4 +2,5 @@
 instagram: https://www.instagram.com/monashhpt/
 facebook: https://www.facebook.com/MonashHPT/
 linkedIn: https://www.linkedin.com/company/monashhpt/
+github: https://github.com/monash-human-power
 ---

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -18,6 +18,7 @@ collections:
           - { label: Instagram Link, name: instagram, widget: string }
           - { label: Facebook Link, name: facebook, widget: string }
           - { label: LinkedIn Link, name: linkedIn, widget: string }
+          - { label: Github Link, name: github, widget: string }
       - label: "Index"
         name: "index"
         file: "/src/markdown/index.md"


### PR DESCRIPTION
## Description

Fix's the big logo on load by setting inline styles. Also added GitHub logo to connect with MHP on GitHub.



## Screenshots

<img width="1024" alt="Screen Shot 2020-09-03 at 11 12 13 am" src="https://user-images.githubusercontent.com/23159604/92060112-53076800-edd6-11ea-8779-4e5a159ff221.png">
nice and proportia
<!--- Attach any screenshots relevant to your change --->

## Steps to Test

Check it out [here](https://deploy-preview-11--mhp-test.netlify.app)

🤞 There should be no big logo.

<!--- How does someone check your change? --->
