### PR TITLE
Fix tiny sponsors on mobile phone

### DIFF
--- a/src/components/index/sponsors.js
+++ b/src/components/index/sponsors.js
@@ -39,11 +39,12 @@ const Sponsors = ({ className }) => {
   return (
     <div className={className}>
       <SponsorHeading className="p-3 my-2"> Sponsors </SponsorHeading>
-      <div className="row">
+      <div className="row justify-content-md-center">
         {sponsorArr.map((sponsorObj, index) => (
-          <div className="col" key={index}>
+          <div className="col-6 col-md-3" key={index}>
             <Img
-              className="m-2"
+              // TODO: Find out why this works
+              className="m-4 mx-auto"
               fluid={sponsorObj.image.childImageSharp.fluid}
             />
           </div>


### PR DESCRIPTION
## Description

As the title says just a small change that makes the sponsor images human readable on a phone.

## Screenshots

### OLD
![image](https://user-images.githubusercontent.com/23159604/96999416-d8123080-1580-11eb-8c0a-9191c4ca65ee.png)

### NEW
![image](https://user-images.githubusercontent.com/23159604/96999468-e9f3d380-1580-11eb-82ca-0bde9397a3b1.png)


## Steps to Test
To test locally, clone and run:
`gatsby develop`
