### PR TITLE
Restore form functionality 

### DIFF
--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -16,6 +16,7 @@ const ContactForm = ({ className }) => (
         <ContactUsHeading className="p-3">Contact Us</ContactUsHeading>
 
         <form
+          // "name" attribute is what the form is called on Netlify
           name="contact"
           method="POST"
           data-netlify="true"

--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -16,13 +16,12 @@ const ContactForm = ({ className }) => (
         <ContactUsHeading className="p-3">Contact Us</ContactUsHeading>
 
         <form
-          // "name" attribute is what the form is called on Netlify
-          name="contact"
+          name="contact" // "name" HTML attribute is the displayed form name on Netlify
           method="POST"
           data-netlify="true"
           data-netlify-honeypot="bot-field"
         >
-          {/* IMPORTANT: every input has to have a name attribute. This will show up on netlify UI */}
+          {/* IMPORTANT: Every input has to have a name attribute. This will show up on netlify UI. */}
 
           {/* This hidden type is needed for the netlify form to work with Gatsby */}
           <input type="hidden" name="form-name" value="contact" />

--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -17,9 +17,9 @@ const ContactForm = ({ className }) => (
 
         <form
           name="contact"
-          method="post"
+          method="POST"
           data-netlify="true"
-          data-netlify-honeypot="bot-field"
+          netlify-honeypot="bot-field"
         >
           {/* This hidden type is needed for the netlify form to work */}
           <input type="hidden" name="form-name" value="contact" />

--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -22,10 +22,13 @@ const ContactForm = ({ className }) => (
           data-netlify="true"
           netlify-honeypot="bot-field"
         >
+          {/* IMPORTANT: every input has to have a name attribute. This will show up on netlify UI */}
+
           {/* Name Input */}
           <div className="form-group">
             <label htmlFor="inputName">Name</label>
             <input
+              name="name"
               type="text"
               className="form-control"
               id="inputName"
@@ -38,6 +41,7 @@ const ContactForm = ({ className }) => (
           <div className="form-group">
             <label htmlFor="inputEmail">Email Address</label>
             <input
+              name="email"
               type="email"
               className="form-control"
               id="inputEmail"
@@ -51,6 +55,7 @@ const ContactForm = ({ className }) => (
           <div className="form-group">
             <label htmlFor="inputText">Message</label>
             <textarea
+              name="message"
               className="form-control"
               id="inputText"
               placeholder=""

--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -21,9 +21,6 @@ const ContactForm = ({ className }) => (
           data-netlify="true"
           netlify-honeypot="bot-field"
         >
-          {/* This hidden type is needed for the netlify form to work */}
-          <input type="hidden" name="form-name" value="contact" />
-
           {/* Name Input */}
           <div className="form-group">
             <label htmlFor="inputName">Name</label>

--- a/src/components/index/contact_form.js
+++ b/src/components/index/contact_form.js
@@ -20,9 +20,12 @@ const ContactForm = ({ className }) => (
           name="contact"
           method="POST"
           data-netlify="true"
-          netlify-honeypot="bot-field"
+          data-netlify-honeypot="bot-field"
         >
           {/* IMPORTANT: every input has to have a name attribute. This will show up on netlify UI */}
+
+          {/* This hidden type is needed for the netlify form to work with Gatsby */}
+          <input type="hidden" name="form-name" value="contact" />
 
           {/* Name Input */}
           <div className="form-group">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -89,8 +89,7 @@ const IndexPage = () => {
         <Sponsors className="my-5 py-5" />
 
         {/* Contact Form */}
-        {/* Hide contact form as it's currently broken */}
-        {/* <ContactForm className="my-5 py-5" /> */}
+        <ContactForm className="my-5 py-5" />
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Description

Fixed the form filling in behavior. I believe the fix was to add the name attributes for each of the HTML input elements. Netlify form docs are incredibly bad and are incorrect for Gatsby. The correct method is located in a blog post that they made.

## Screenshots

### Netlify displaying correct test input

![image (1)](https://user-images.githubusercontent.com/23159604/97150654-8ce76000-17c2-11eb-8723-1f4403b1abd7.png)



## Steps to Test

Fill in the form with dummy information using this link:

https://deploy-preview-67--mhp-test.netlify.app/

### ONLY DO THIS ONCE AS OVER 100 FORM FILL INS WILL INCUR A CHARGE


