### PR TITLE
Fix Netlify issue + add links to sponsor logos

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -88,10 +88,12 @@ const Header = () => {
                 style={{ display: "flex" }}
               >
                 {/* MHP logo */}
-                <Img
-                  className="align-top"
-                  fixed={data.file.childImageSharp.fixed}
-                />
+                <Link to="/">
+                  <Img
+                    className="align-top"
+                    fixed={data.file.childImageSharp.fixed}
+                  />
+                </Link>
                 <NavLink className="nav-link" to="/">
                   MHP
                 </NavLink>

--- a/src/components/index/sponsors.js
+++ b/src/components/index/sponsors.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import Link from "../link";
 import Img from "gatsby-image";
 import { useStaticQuery, graphql } from "gatsby";
 
@@ -21,6 +22,7 @@ const Sponsors = ({ className }) => {
                   }
                 }
               }
+              link
             }
           }
         }
@@ -40,11 +42,13 @@ const Sponsors = ({ className }) => {
       <div className="row justify-content-md-center">
         {sponsorArr.map((sponsorObj, index) => (
           <div className="col-6 col-md-3" key={index}>
-            <Img
-              // TODO: Find out why this works
-              className="m-4 mx-auto"
-              fluid={sponsorObj.image.childImageSharp.fluid}
-            />
+            <Link to={sponsorObj.link} target="_blank">
+              <Img
+                // TODO: Find out why this works
+                className="m-4 mx-auto"
+                fluid={sponsorObj.image.childImageSharp.fluid}
+              />
+            </Link>
           </div>
         ))}
       </div>

--- a/src/markdown/index.md
+++ b/src/markdown/index.md
@@ -80,14 +80,20 @@ subteams:
 sponsors:
   - name: Monash University
     image: ../images/monash-current-logo.png
+    link: "https://www.monash.edu"
   - name: The Department of Mechanical and Aerospace Engineering
     image: ../images/mae-hq-logo.png
+    link: "https://www.monash.edu/engineering/departments/mechanical"
   - name: AARC
     image: ../images/aarc-logo_high-res.jpg
+    link: "https://aarconline.com"
   - name: Ford
     image: ../images/ford-logo-icon-0.png
+    link: "https://www.ford.com.au"
   - name: "Leap "
     image: ../images/leap-hq-logo.png
+    link: "https://www.leapaust.com.au"
   - name: C5 systems
     image: ../images/c5-logo.png
+    link: "https://c5systems.com.au"
 ---

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -266,13 +266,6 @@ collections:
                   hint: "If you are not changing the header, don't mess with it!",
                 }
               - {
-                  label: Button Text,
-                  name: buttonText,
-                  widget: string,
-                  default: "",
-                  required: false,
-                }
-              - {
                   label: Button Link,
                   name: href,
                   widget: string,


### PR DESCRIPTION
## Description

3 small changes:
- Fix issue with Netlify admin CMS failing due to duplicate `fields` names
- Make MHP logo in the header also clickable (the text is already clickable)
- Add links to the current sponsor's respective sites

## Screenshots

N/A, no visual changes made

## Steps to Test

1) Run `yarn develop` and check that each sponsor logo is clickable and leads to correct sponsor website. 
2) Check Netlify CMS is working
3) Check MHP logo in the header works as expected
