### PR TITLE
Add link to recruitment form

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styled from "styled-components";
+import { useStaticQuery, graphql } from "gatsby";
 
 import Link from "./link";
 import Socials from "./socials";
@@ -29,62 +30,87 @@ const TinyFooterParagraph = styled.p`
 
 const CURRENT_YEAR = new Date().getFullYear();
 
-const Footer = () => (
-  <MhpFooter className="pt-3">
-    <div className="container">
-      <div className="row">
-        {/* Sponsor section */}
-        <div className="col-md">
-          <FooterHeading>Sponsor Us</FooterHeading>
-          <FooterParagraph>
-            Get in touch with us today at
-            <FooterLink to="mailto: monashhpt@gmail.com">
+const Footer = () => {
+  const recruitment_data = useStaticQuery(graphql`
+    query RecruitmentInfoQuery {
+      file(
+        relativePath: { eq: "index.md" }
+        sourceInstanceName: { eq: "markdown" }
+      ) {
+        childMarkdownRemark {
+          frontmatter {
+            recruitment_link
+          }
+        }
+      }
+    }
+  `);
+
+  return (
+    <MhpFooter className="pt-3">
+      <div className="container">
+        <div className="row">
+          {/* Sponsor section */}
+          <div className="col-md">
+            <FooterHeading>Sponsor Us</FooterHeading>
+            <FooterParagraph>
+              Get in touch with us today at
+              <FooterLink to="mailto: monashhpt@gmail.com">
+                {" "}
+                monashhpt@gmail.com
+              </FooterLink>
+            </FooterParagraph>
+          </div>
+
+          {/* Address section */}
+          <div className="col-md">
+            <FooterHeading>Say Hello</FooterHeading>
+            <FooterParagraph>
+              17 Alliance Lane, Monash University
+            </FooterParagraph>
+          </div>
+
+          {/* Social text */}
+          <div className="col-md">
+            <FooterHeading>Join Us</FooterHeading>
+            <FooterParagraph>
+              Let's beat the world record together!
+              <br />
+              <FooterLink
+                to={
+                  recruitment_data.file.childMarkdownRemark.frontmatter
+                    .recruitment_link
+                }
+              >
+                {" "}
+                Apply here
+              </FooterLink>
+            </FooterParagraph>
+          </div>
+
+          {/* Social icons */}
+          <div className="col-md">
+            <Socials />
+          </div>
+        </div>
+
+        <div className="row">
+          {/* Col is xl as it should always collapse */}
+          <div className="col-xl">
+            <TinyFooterParagraph>
               {" "}
-              monashhpt@gmail.com
-            </FooterLink>
-          </FooterParagraph>
-        </div>
-
-        {/* Address section */}
-        <div className="col-md">
-          <FooterHeading>Say Hello</FooterHeading>
-          <FooterParagraph>17 Alliance Lane, Monash University</FooterParagraph>
-        </div>
-
-        {/* Social text */}
-        <div className="col-md">
-          <FooterHeading>Join Us</FooterHeading>
-          <FooterParagraph>
-            Connect with us on
-            <FooterLink to="https://www.facebook.com/MonashHumanPower/">
-              {" "}
-              Facebook
-            </FooterLink>
-          </FooterParagraph>
-        </div>
-
-        {/* Social icons */}
-        <div className="col-md">
-          <Socials />
+              &#169; {CURRENT_YEAR}, Monash Human Power{" "}
+            </TinyFooterParagraph>
+            <TinyFooterParagraph>
+              We wish to acknowledge the Wurundjeri People of the Kulin Nations,
+              on whose land we build our bikes and pay our respects to their
+              Elders, past and present.
+            </TinyFooterParagraph>
+          </div>
         </div>
       </div>
-
-      <div className="row">
-        {/* Col is xl as it should always collapse */}
-        <div className="col-xl">
-          <TinyFooterParagraph>
-            {" "}
-            &#169; {CURRENT_YEAR}, Monash Human Power{" "}
-          </TinyFooterParagraph>
-          <TinyFooterParagraph>
-            We wish to acknowledge the Wurundjeri People of the Kulin Nations,
-            on whose land we build our bikes and pay our respects to their
-            Elders, past and present.
-          </TinyFooterParagraph>
-        </div>
-      </div>
-    </div>
-  </MhpFooter>
-);
+    </MhpFooter>
+  );
+};
 
 export default Footer;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -78,8 +78,6 @@ const Header = () => {
     },
   ];
 
-  console.log(pageLinks);
-
   return (
     <header>
       <Navbar className="navbar fixed-top navbar-expand-lg navbar-dark">

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -45,10 +45,20 @@ function navItem(text, anchor = "#", key) {
 const Header = () => {
   const data = useStaticQuery(graphql`
     query Logo {
-      file(relativePath: { eq: "MHP_logo_green_transparent.png" }) {
+      logoData: file(relativePath: { eq: "MHP_logo_green_transparent.png" }) {
         childImageSharp {
           fixed(height: 30) {
             ...GatsbyImageSharpFixed
+          }
+        }
+      }
+      recruitmentData: file(
+        relativePath: { eq: "index.md" }
+        sourceInstanceName: { eq: "markdown" }
+      ) {
+        childMarkdownRemark {
+          frontmatter {
+            recruitment_link
           }
         }
       }
@@ -61,7 +71,14 @@ const Header = () => {
     { title: "Bike", link: "/bike" },
     { title: "Subteams", link: "/subteams" },
     { title: "Outreach", link: "/outreach" },
+    {
+      title: "Join Us",
+      link:
+        data.recruitmentData.childMarkdownRemark.frontmatter.recruitment_link,
+    },
   ];
+
+  console.log(pageLinks);
 
   return (
     <header>
@@ -91,7 +108,7 @@ const Header = () => {
                 <Link to="/">
                   <Img
                     className="align-top"
-                    fixed={data.file.childImageSharp.fixed}
+                    fixed={data.logoData.childImageSharp.fixed}
                   />
                 </Link>
                 <NavLink className="nav-link" to="/">

--- a/src/components/index/sponsors.js
+++ b/src/components/index/sponsors.js
@@ -42,7 +42,7 @@ const Sponsors = ({ className }) => {
       <div className="row justify-content-md-center">
         {sponsorArr.map((sponsorObj, index) => (
           <div className="col-6 col-md-3" key={index}>
-            <Link to={sponsorObj.link} target="_blank">
+            <Link to={sponsorObj.link}>
               <Img
                 // TODO: Find out why this works
                 className="m-4 mx-auto"

--- a/src/components/link.js
+++ b/src/components/link.js
@@ -26,7 +26,7 @@ const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
     );
   }
   return (
-    <a href={to} {...other}>
+    <a href={to} target="_blank" rel="noreferrer" {...other}>
       {children}
     </a>
   );

--- a/src/markdown/index.md
+++ b/src/markdown/index.md
@@ -2,6 +2,7 @@
 heading: Monash Human Power
 image: ../images/V3_render_cool.png
 meta_page_description: ""
+recruitment_link: https://docs.google.com/forms/d/e/1FAIpQLSfy0FNRq9MqouoOTNTW6ZqT5IwkO91LOtFDFkxVfRAw_OkN2A/viewform
 blocks:
   - heading: Who we are
     description:


### PR DESCRIPTION
## Description

This PR adds a 'JOIN US' button to the header. This should ideally direct to our own 'Join US" page on the website, but since that will take a time to build and the recruitment is currently ongoing, we will make the button directly send users to our google form to apply for a position.

Also updated the 'JOIN US' section in the footer to add our recruitment form. Remove the previous message 'Connect with us on Facebook', since they can still do that using the social icons in the footer, and if we want we can bring it back after the current recruitment round.

## Screenshots
<img width="492" alt="Screen Shot 2022-03-01 at 5 50 21 pm" src="https://user-images.githubusercontent.com/63642262/156121504-23c7843f-5cb5-4898-b3c9-4210b7826326.png">

Clicking on 'JOIN US' or the 'Apply here' embedded link should open a new tab with the following google form:
<img width="957" alt="Screen Shot 2022-03-01 at 5 50 33 pm" src="https://user-images.githubusercontent.com/63642262/156121509-9fa69363-5320-42c0-8bcf-3eaa56c0b35e.png">


## Steps to Test

1) Run `yarn develop` and check the join us button and the footer is updated as expected. 
2) Test out the buttons!
