### PR TITLE
Make blog subtitle optional

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -470,6 +470,7 @@ collections:
       - label: "Subtitle"
         name: subtitle
         widget: string
+        required: false
       - label: "Author"
         name: author
         widget: string


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->

Quick fix: make the subtitle field in netlify CMS blog posts optional.

## Screenshots

<!--- Attach any screenshots relevant to your change --->

## Steps to Test

<!--- How does someone check your change? --->

Look at the admin page, and try to create blog posts.
