### PR TITLE
Centre the sponsors vertically

### DIFF
--- a/src/components/index/sponsors.js
+++ b/src/components/index/sponsors.js
@@ -39,7 +39,7 @@ const Sponsors = ({ className }) => {
         <SectionHeading>Sponsors</SectionHeading>
       </div>
 
-      <div className="row justify-content-md-center">
+      <div className="row justify-content-md-center align-items-center">
         {sponsorArr.map((sponsorObj, index) => (
           <div className="col-6 col-md-3" key={index}>
             <Link to={sponsorObj.link}>


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->

Centre the sponsors vertically so they look nice when the logos have different width

## Screenshots

<!--- Attach any screenshots relevant to your change --->

Before:
![Screenshot from 2023-03-22 19-37-44](https://user-images.githubusercontent.com/34503494/226847101-a96e089b-ae27-40a7-b6f4-993400d4c00e.png)

After:
![Screenshot from 2023-03-22 19-37-33](https://user-images.githubusercontent.com/34503494/226847135-8785def9-0f63-4585-a466-2402a0a96a5d.png)


## Steps to Test

<!--- How does someone check your change? --->

Build as normal, and scroll through the bottom of the homepage. The logo should be centred vertically.