### PR TITLE
Change dependabot schedule from weekly to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,4 @@ updates:
   - directory: /
     package-ecosystem: "npm"
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->

IMO there's just way too many pull requests for dependency updates. The vast majority of them are very small changes, and it's just end up being a maintenance burden. Reducing the frequency to monthly hopefully reduces the number of PRs while ensuring that we don't fall behind too far and requiring the big update every few months/years.

## Screenshots

<!--- Attach any screenshots relevant to your change --->

## Steps to Test

<!--- How does someone check your change? --->
