### PR TITLE
Add link to prospectus and tweak footer links

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -44,11 +44,17 @@ const Footer = () => {
         childMarkdownRemark {
           frontmatter {
             recruitment_info
+            prospectus_link
+            contact_email
           }
         }
       }
     }
   `);
+
+  const frontMatter = recruitment_data.file.childMarkdownRemark.frontmatter;
+  const email = frontMatter.contact_email;
+  const prospectusLink = frontMatter.prospectus_link;
 
   return (
     <MhpFooter className="pt-3">
@@ -57,12 +63,15 @@ const Footer = () => {
           {/* Sponsor section */}
           <div className="col-md">
             <FooterHeading>Sponsor Us</FooterHeading>
+            <FooterParagraph>Get in touch with us today!</FooterParagraph>
             <FooterParagraph>
-              Get in touch with us today at
-              <FooterLink to="mailto: monashhpt@gmail.com">
-                {" "}
-                monashhpt@gmail.com
-              </FooterLink>
+              <FooterLink to={prospectusLink}>Read the prospectus</FooterLink>
+            </FooterParagraph>
+            <FooterParagraph>
+              <FooterLink to="/#contact">Contact us</FooterLink>
+            </FooterParagraph>
+            <FooterParagraph>
+              <FooterLink to={"mailto:" + email}>Send us an email</FooterLink>
             </FooterParagraph>
           </div>
 
@@ -104,8 +113,7 @@ const Footer = () => {
           {/* Col is xl as it should always collapse */}
           <div className="col-xl">
             <TinyFooterParagraph>
-              {" "}
-              &#169; {CURRENT_YEAR}, Monash Human Power{" "}
+              &copy; {CURRENT_YEAR} Monash Human Power
             </TinyFooterParagraph>
             <TinyFooterParagraph>
               We wish to acknowledge the Wurundjeri People of the Kulin Nations,

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -67,7 +67,7 @@ const Footer = () => {
             <FooterParagraph>
               Get in touch with us today!
               <br />
-              <FooterLink to={prospectusLink}>Read the prospectus</FooterLink>
+              <FooterLink to={prospectusLink}>Prospectus</FooterLink>
               <br />
               <FooterLink to="/#contact">Contact us</FooterLink>
             </FooterParagraph>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -35,7 +35,7 @@ const TinyFooterParagraph = styled.p`
 const CURRENT_YEAR = new Date().getFullYear();
 
 const Footer = () => {
-  const recruitment_data = useStaticQuery(graphql`
+  const data = useStaticQuery(graphql`
     query RecruitmentInfoQuery {
       file(
         relativePath: { eq: "index.md" }
@@ -52,9 +52,10 @@ const Footer = () => {
     }
   `);
 
-  const frontMatter = recruitment_data.file.childMarkdownRemark.frontmatter;
+  const frontMatter = data.file.childMarkdownRemark.frontmatter;
   const email = frontMatter.contact_email;
   const prospectusLink = frontMatter.prospectus_link;
+  const recruitmentInfo = frontMatter.recruitment_info;
 
   return (
     <MhpFooter className="pt-3">
@@ -91,14 +92,7 @@ const Footer = () => {
             <FooterParagraph>
               Let's beat the world record together!
               <br />
-              <FooterLink
-                to={
-                  recruitment_data.file.childMarkdownRemark.frontmatter
-                    .recruitment_info
-                }
-              >
-                Recruitment page
-              </FooterLink>
+              <FooterLink to={recruitmentInfo}>Learn more</FooterLink>
             </FooterParagraph>
           </div>
 

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -64,15 +64,12 @@ const Footer = () => {
           {/* Sponsor section */}
           <div className="col-md">
             <FooterHeading>Sponsor Us</FooterHeading>
-            <FooterParagraph>Get in touch with us today!</FooterParagraph>
             <FooterParagraph>
+              Get in touch with us today!
+              <br />
               <FooterLink to={prospectusLink}>Read the prospectus</FooterLink>
-            </FooterParagraph>
-            <FooterParagraph>
+              <br />
               <FooterLink to="/#contact">Contact us</FooterLink>
-            </FooterParagraph>
-            <FooterParagraph>
-              <FooterLink to={"mailto:" + email}>Send us an email</FooterLink>
             </FooterParagraph>
           </div>
 
@@ -82,7 +79,8 @@ const Footer = () => {
             <MhpAddress>
               Monash Makerspace <br />
               23 College Walk <br />
-              Monash University VIC 3800
+              Monash University VIC 3800 <br />
+              Email: <FooterLink to={"mailto:" + email}>{email}</FooterLink>
             </MhpAddress>
           </div>
 

--- a/src/components/socials.js
+++ b/src/components/socials.js
@@ -57,35 +57,35 @@ const Socials = () => {
   // Inline style for FontAwesomeIcon ensures that the styles gets loaded immediately with the HTML (no huge icons)
   return (
     <MhpSocialContainer>
-      <SocialLink to={social_link.facebook}>
+      <SocialLink to={social_link.facebook} title="Facebook">
         <FontAwesomeIcon
           style={{ height: iconSize, width: iconSize }}
           icon={faFacebook}
         />
       </SocialLink>
 
-      <SocialLink to={social_link.instagram}>
+      <SocialLink to={social_link.instagram} title="Instagram">
         <FontAwesomeIcon
           style={{ height: iconSize, width: iconSize }}
           icon={faInstagram}
         />
       </SocialLink>
 
-      <SocialLink to={social_link.linkedIn}>
+      <SocialLink to={social_link.linkedIn} title="LinkedIn">
         <FontAwesomeIcon
           style={{ height: iconSize, width: iconSize }}
           icon={faLinkedin}
         />
       </SocialLink>
 
-      <SocialLink to={social_link.github}>
+      <SocialLink to={social_link.github} title="GitHub">
         <FontAwesomeIcon
           style={{ height: iconSize, width: iconSize }}
           icon={faGithub}
         />
       </SocialLink>
 
-      <SocialLink to={social_link.tiktok}>
+      <SocialLink to={social_link.tiktok} title="TikTok">
         <FontAwesomeIcon
           style={{ height: iconSize, width: iconSize }}
           icon={faTiktok}

--- a/src/markdown/index.md
+++ b/src/markdown/index.md
@@ -43,4 +43,7 @@ sponsors:
   - name: Yarra Energy
     image: ../images/yarraenergy_logo_col.png
     link: https://yarraenergy.com.au/
+# sponsor section links
+prospectus_link: https://drive.google.com/file/d/1T2sDXsO7OtHV8oJ1w3u903o1ycFrhjH-/view?usp=sharing
+contact_email: monashhpt@gmail.com
 ---


### PR DESCRIPTION
## Description

<!--- What does your pull request change? What changes are expected? --->

- Add link to prospectus in the footer in sponsor us section

Notes:

There are a few variants to how the contact links should be shown, see screenshots below. Any feedback would be appreciated.

It might also be a good idea to put some more info under the sponsor section of home page.

## Screenshots

<!--- Attach any screenshots relevant to your change --->

Variant 1: link to contact form and email shown
![Screenshot from 2023-06-29 12-41-37](https://github.com/monash-human-power/MHP-website/assets/34503494/67ce402f-c094-48b3-a8dc-e999e51f5997)

Variant 2: only link to contact form shown
![Screenshot from 2023-06-29 12-42-19](https://github.com/monash-human-power/MHP-website/assets/34503494/67221d8f-0a64-4749-8c92-3ecb357d662f)

Variant 3: only link to email shown
![Screenshot from 2023-06-29 12-42-32](https://github.com/monash-human-power/MHP-website/assets/34503494/9790df98-9001-40b2-834b-24634bae34ac)


Variant 4: email link under address
![Screenshot from 2023-06-29 12-56-07](https://github.com/monash-human-power/MHP-website/assets/34503494/3b7b45db-49c0-4644-8696-40612aee7dce)


## Steps to Test

<!--- How does someone check your change? --->

Build as normal.
