### PR TITLE
Update MHP “about”

### DIFF
--- a/src/markdown/about.md
+++ b/src/markdown/about.md
@@ -3,8 +3,7 @@ heading: About
 meta_page_description: About MHP
 blocks:
   - heading: Who we are
-    description:
-      "Monash Human Power is a student-led engineering team from Monash
+    description: "Monash Human Power is a student-led engineering team from Monash
       University in Melbourne, Australia. Since 2015 we have been designing,
       manufacturing, and racing fully-faired human-powered vehicles (HPV) to
       push the limits of human speed. "
@@ -14,23 +13,26 @@ blocks:
     id: team
   - heading: Our Mission
     description: Our team is aiming to break the Australian HPV F200 land speed
-      record of 96.7 km/h, as well as represent Australia at the World Human Powered Vehicle Speed Challenge in Las
-      Vegas, NV. We take pride in developing industry-ready graduates through our collaborative design and manufacturing
-      process. We believe that HPV provides a relevant and immersive framework for learning STEM and we use this
-      framework to promote sustainability in schools.
+      record of 96.7 km/h, as well as represent Australia at the World Human
+      Powered Vehicle Speed Challenge in Las Vegas, NV. We take pride in
+      developing industry-ready graduates through our collaborative design and
+      manufacturing process. We believe that HPV provides a relevant and
+      immersive framework for learning STEM and we use this framework to promote
+      sustainability in schools.
     buttonText: See the bike
     image: ../images/our-mission.jpeg
     href: /bike
     id: bike
   - heading: The Competitions
-    description: MHP participates in several HPV competitions in Australia and around the world, such as the World Human Powered Speed ChalMaking something we can all be proud oflenge in Nevada.
+    description: MHP participates in several HPV competitions in Australia and
+      around the world, such as the World Human Powered Speed Challenge. Making
+      something we can all be proud of in Nevada.
     buttonText: See the Competitions
     image: ../images/competitions-about.jpg
     href: /competitions
     id: competitions
   - heading: Outreach
-    description:
-      Monash Human Power is proud to offer a robust schools program that
+    description: Monash Human Power is proud to offer a robust schools program that
       is tailored to the 'Science as a human endeavour' Level 9 and 10 Science
       achievement standards of the Victorian Curriculum. We hope to inspire a
       passion for STEM and sustainability in your students. We also run
@@ -40,7 +42,13 @@ blocks:
     id: outreach
     buttonText: Learn More
     href: /outreach
-
+our_values:
+  - heading: Quality
+    body: ""
+  - heading: Pride
+    body: ""
+  - heading: Consistency
+    body: ""
 subteams:
   - name: Aerodynamics
     description: Responsible for the design and testing of the external shell
@@ -49,15 +57,13 @@ subteams:
     button_href: ""
     id: aerodynamics
   - name: Operations
-    description:
-      Works behind the scenes to support the technical side of the team
+    description: Works behind the scenes to support the technical side of the team
       by coordinating marketing, events, and sponsorship.
     button_text: ""
     button_href: ""
     id: operations
   - name: Chassis & Drive-train
-    description:
-      Responsible for the design and manufacture of the chassis and all
+    description: Responsible for the design and manufacture of the chassis and all
       other mechanical components of the vehicle.
     button_text: ""
     button_href: ""
@@ -77,12 +83,4 @@ subteams:
     button_text: ""
     button_href: ""
     id: rider-development
-
-our_values:
-  - heading: Quality
-    body: ""
-  - heading: Pride
-    body: ""
-  - heading: Consistency
-    body: ""
 ---


### PR DESCRIPTION
Corrected a spelling error in the 'The Competitions' block in the 'About' page .